### PR TITLE
Adds missing logger to the OPA Backend

### DIFF
--- a/packages/backend/src/plugins/permission.ts
+++ b/packages/backend/src/plugins/permission.ts
@@ -16,7 +16,7 @@ export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   const opaClient = new OpaClient(env.config, env.logger);
-  const genericPolicyEvaluator = policyEvaluator(opaClient);
+  const genericPolicyEvaluator = policyEvaluator(opaClient, env.logger);
   class PermissionsHandler implements PermissionPolicy {
     async handle(
       request: PolicyQuery,


### PR DESCRIPTION
The logger is missing from the OPA backend Policy Evaluator.

This adds the logger.