### PR TITLE
Add a fallback policy to be used whenever OPA server is unresponsive/unreachable

### DIFF
--- a/.changeset/happy-taxis-buy.md
+++ b/.changeset/happy-taxis-buy.md
@@ -1,0 +1,5 @@
+---
+'@parsifal-m/plugin-permission-backend-module-opa-wrapper': minor
+---
+
+Added configuration option to add blanket fallback policies in the case that OPA server is unreachable. No functional changes occur if the config variable is not added in the app-config.yaml, save for a reworded logger message.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -123,3 +123,7 @@ opaClient:
       entrypoint: 'entity_checker/violation'
     permissions: # Permission wrapper plugin
       entrypoint: 'rbac_policy/decision'
+      ## Uncomment this line to add a fallback policy in case the connection with OPA fails
+      ##   Values can be 'allow' to blindly ALLOW all requests or 'deny' to blindly DENY all requests. Any other value
+      ##   allows errors to be thrown when the connection with OPA fails.
+      # policyFallback: 'allow' # Values: 'allow' or 'deny'

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -123,7 +123,7 @@ opaClient:
       entrypoint: 'entity_checker/violation'
     permissions: # Permission wrapper plugin
       entrypoint: 'rbac_policy/decision'
-      ## Uncomment this line to add a fallback policy in case the connection with OPA fails
-      ##   Values can be 'allow' to blindly ALLOW all requests or 'deny' to blindly DENY all requests. Any other value
+      ## Uncomment this line to add a fallback policy in case there is an issue fetching a policy from OPA
+      ##   Values can be 'allow' to ALLOW all requests or 'deny' to DENY all requests. Any other value
       ##   allows errors to be thrown when the connection with OPA fails.
       # policyFallback: 'allow' # Values: 'allow' or 'deny'

--- a/docs/opa-permissions-wrapper-module/local-development.md
+++ b/docs/opa-permissions-wrapper-module/local-development.md
@@ -53,8 +53,8 @@ opaClient:
       policyFallback: 'deny'
 ```
 
-The previous example would return a `DENY` decision to any request if the OPA server is not reachable.
-If the value is set to any value other than `allow` or `deny`, the wrapper is allowed to throw an error if the OPA server is not reachable. The values are case-insensitive.
+The previous example would return a `DENY` decision to any permission request if the OPA server is not reachable.
+If you do not enable a `policyFallback`, the wrapper will simply throw an error if the OPA server is not reachable and a permission request is made. The values are case-insensitive.
 
 ## Docker Compose
 

--- a/docs/opa-permissions-wrapper-module/local-development.md
+++ b/docs/opa-permissions-wrapper-module/local-development.md
@@ -40,6 +40,22 @@ opaClient:
       entrypoint: 'rbac_policy/decision'
 ```
 
+### Fallback policy
+
+Two basic fallback policies are provided in the plugin, `allow` and `deny`. You can set the default policy in the `app-config.yaml` file with the `policyFallback` key:
+
+```yaml
+opaClient:
+  baseUrl: 'http://localhost:8181'
+  policies:
+    permissions: # Permission wrapper plugin
+      entrypoint: 'rbac_policy/decision'
+      policyFallback: 'deny' 
+```
+
+The previous example would return a `DENY` decision to any request if the OPA server is not reachable.
+If the value is set to any value other than `allow` or `deny`, the wrapper is allowed to throw an error if the OPA server is not reachable. The values are case-insensitive.
+
 ## Docker Compose
 
 You can create a `docker-compose.yaml` file in the root of the repository with the following content:

--- a/docs/opa-permissions-wrapper-module/local-development.md
+++ b/docs/opa-permissions-wrapper-module/local-development.md
@@ -50,7 +50,7 @@ opaClient:
   policies:
     permissions: # Permission wrapper plugin
       entrypoint: 'rbac_policy/decision'
-      policyFallback: 'deny' 
+      policyFallback: 'deny'
 ```
 
 The previous example would return a `DENY` decision to any request if the OPA server is not reachable.

--- a/plugins/backstage-opa-backend/config.d.ts
+++ b/plugins/backstage-opa-backend/config.d.ts
@@ -29,6 +29,11 @@ export interface Config {
          * The entrypoint to the OPA Permissions Wrapper
          */
         entrypoint?: string;
+
+        /**
+         * The fallback policy to use when the OPA server is unavailable
+         */
+        policyFallback?: string;
       };
     };
   };

--- a/plugins/permission-backend-module-opa-wrapper/README.md
+++ b/plugins/permission-backend-module-opa-wrapper/README.md
@@ -62,11 +62,31 @@ opaClient:
       entrypoint: 'rbac_policy/decision'
 ```
 
+
+
 The `baseUrl` is the URL of the OPA server, and the `entrypoint` is the entrypoint of the policy you want to evaluate.
 
 It is also possible to provide an entrypoint to the `policyEvaluator` function, this will override the entrypoint provided in the config. This allows for more flexibility in policy evaluation (if you need it).
 
 If you do not override the entrypoint, the entrypoint provided in the config will be used.
+
+
+### Fallback policy
+
+Two basic fallback policies are provided in the plugin, `allow` and `deny`. You can set the default policy in the `app-config.yaml` file with the `policyFallback` key:
+
+```yaml
+opaClient:
+  baseUrl: 'http://localhost:8181'
+  policies:
+    permissions: # Permission wrapper plugin
+      entrypoint: 'rbac_policy/decision'
+      policyFallback: 'deny' 
+```
+
+The previous example would return a `DENY` decision to any request if the OPA server is not reachable.
+If the value is set to any value other than `allow` or `deny`, the wrapper is allowed to throw an error if the OPA server is not reachable. The values are case-insensitive.
+
 
 ## An Example Policy and Input
 

--- a/plugins/permission-backend-module-opa-wrapper/README.md
+++ b/plugins/permission-backend-module-opa-wrapper/README.md
@@ -62,14 +62,11 @@ opaClient:
       entrypoint: 'rbac_policy/decision'
 ```
 
-
-
 The `baseUrl` is the URL of the OPA server, and the `entrypoint` is the entrypoint of the policy you want to evaluate.
 
 It is also possible to provide an entrypoint to the `policyEvaluator` function, this will override the entrypoint provided in the config. This allows for more flexibility in policy evaluation (if you need it).
 
 If you do not override the entrypoint, the entrypoint provided in the config will be used.
-
 
 ### Fallback policy
 
@@ -81,12 +78,11 @@ opaClient:
   policies:
     permissions: # Permission wrapper plugin
       entrypoint: 'rbac_policy/decision'
-      policyFallback: 'deny' 
+      policyFallback: 'deny'
 ```
 
 The previous example would return a `DENY` decision to any request if the OPA server is not reachable.
 If the value is set to any value other than `allow` or `deny`, the wrapper is allowed to throw an error if the OPA server is not reachable. The values are case-insensitive.
-
 
 ## An Example Policy and Input
 

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -104,8 +104,10 @@ describe('OpaClient', () => {
     expect(result).toEqual('DENY');
   });
 
-  it('should return an ALLOW if policyFallback is set to allow', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Fetch error'));
+  it('should return an ALLOW if policyFallback is set to allow and fetch fails', async () => {
+    const mockError = new Error('FetchError');
+    mockError.name = 'FetchError';
+    mockFetch.mockRejectedValueOnce(mockError);
 
     const client = new OpaClient(mockConfig, mockLogger);
     const mockOpaEntrypoint = 'some/admin';
@@ -113,8 +115,31 @@ describe('OpaClient', () => {
       permission: { name: 'read' },
       identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
     };
-    const output = await client.evaluatePolicy(mockInput, mockOpaEntrypoint, 'allow')
+    const output = await client.evaluatePolicy(
+      mockInput,
+      mockOpaEntrypoint,
+      'allow',
+    );
     expect(output.result).toEqual('ALLOW');
+  });
+
+  it('should return a DENY if policyFallback is set to allow and fetch fails', async () => {
+    const mockError = new Error('FetchError');
+    mockError.name = 'FetchError';
+    mockFetch.mockRejectedValueOnce(mockError);
+
+    const client = new OpaClient(mockConfig, mockLogger);
+    const mockOpaEntrypoint = 'some/admin';
+    const mockInput: PolicyEvaluationInput = {
+      permission: { name: 'read' },
+      identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
+    };
+    const output = await client.evaluatePolicy(
+      mockInput,
+      mockOpaEntrypoint,
+      'deny',
+    );
+    expect(output.result).toEqual('DENY');
   });
 
   it('should throw error when response is not ok', async () => {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -146,6 +146,29 @@ describe('OpaClient', () => {
     },
   );
 
+  it('should throw an error if policyFallback is an unknown value and OPA response is not OK', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: jest.fn().mockResolvedValueOnce({}),
+        statusText: 'Bad Request',
+        status: 400,
+      } as any);
+
+      const mockConfigWithPolicyObject: any = structuredClone(mockConfigObject);
+      mockConfigWithPolicyObject.opaClient.policies.permissions.policyFallback = 'TEST_VALUE';
+      const mockConfigWithPolicy = new ConfigReader(mockConfigWithPolicyObject);
+
+      const client = new OpaClient(mockConfigWithPolicy, mockLogger);
+      const mockOpaEntrypoint = 'some/admin';
+      const mockInput: PolicyEvaluationInput = {
+        permission: { name: 'read' },
+        identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
+      };
+        await expect(client.evaluatePolicy(mockInput, mockOpaEntrypoint)).rejects.toThrow();
+
+    },
+  );
+
   it('should throw error when response is not ok', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -165,9 +165,11 @@ describe('OpaClient', () => {
       identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
     };
     const mockOpaEntrypoint = 'some/admin';
-    await expect(client.evaluatePolicy(mockInput, mockOpaEntrypoint))
-        .rejects
-        .toThrow("An error response was returned after sending the policy input to the OPA server:");
+    await expect(
+      client.evaluatePolicy(mockInput, mockOpaEntrypoint),
+    ).rejects.toThrow(
+      'An error response was returned after sending the policy input to the OPA server:',
+    );
   });
 
   it('should throw error when fetch throws an error', async () => {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -114,7 +114,7 @@ describe('OpaClient', () => {
       identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
     };
     const output = await client.evaluatePolicy(mockInput, mockOpaEntrypoint, 'allow')
-    expect(output).toEqual('ALLOW');
+    expect(output.result).toEqual('ALLOW');
   });
 
   it('should throw error when response is not ok', async () => {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -104,7 +104,7 @@ describe('OpaClient', () => {
     expect(result).toEqual('DENY');
   });
 
-  it('should return an ALLOW if policyFallback is set to allow and fetch fails', async () => {
+  it.each(['ALLOW', 'DENY'])('should return %s if policyFallback is set to that value and fetch fails', async (policy) => {
     const mockError = new Error('FetchError');
     mockError.name = 'FetchError';
     mockFetch.mockRejectedValueOnce(mockError);
@@ -118,12 +118,12 @@ describe('OpaClient', () => {
     const output = await client.evaluatePolicy(
       mockInput,
       mockOpaEntrypoint,
-      'allow',
+      policy,
     );
-    expect(output.result).toEqual('ALLOW');
+    expect(output.result).toEqual(policy);
   });
 
-  it('should return a DENY if policyFallback is set to allow and fetch fails', async () => {
+  it('should throw error if policyFallback is set to unknown/null value and fetch fails', async () => {
     const mockError = new Error('FetchError');
     mockError.name = 'FetchError';
     mockFetch.mockRejectedValueOnce(mockError);
@@ -134,12 +134,10 @@ describe('OpaClient', () => {
       permission: { name: 'read' },
       identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
     };
-    const output = await client.evaluatePolicy(
+    await expect(client.evaluatePolicy(
       mockInput,
-      mockOpaEntrypoint,
-      'deny',
-    );
-    expect(output.result).toEqual('DENY');
+      mockOpaEntrypoint
+    )).rejects.toThrow("FetchError");
   });
 
   it('should throw error when response is not ok', async () => {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -104,6 +104,19 @@ describe('OpaClient', () => {
     expect(result).toEqual('DENY');
   });
 
+  it('should return an ALLOW if policyFallback is set to allow', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Fetch error'));
+
+    const client = new OpaClient(mockConfig, mockLogger);
+    const mockOpaEntrypoint = 'some/admin';
+    const mockInput: PolicyEvaluationInput = {
+      permission: { name: 'read' },
+      identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
+    };
+    const output = await client.evaluatePolicy(mockInput, mockOpaEntrypoint, 'allow')
+    expect(output).toEqual('ALLOW');
+  });
+
   it('should throw error when response is not ok', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -34,6 +34,7 @@ describe('OpaClient', () => {
       info: jest.fn(),
       error: jest.fn(),
       debug: jest.fn(),
+      warn: jest.fn(),
     } as unknown as LoggerService;
     mockConfig = new ConfigReader({
       backend: {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -155,6 +155,8 @@ describe('OpaClient', () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       json: jest.fn().mockResolvedValueOnce({}),
+      status: 400,
+      statusText: 'Bad Request',
     } as any);
 
     const client = new OpaClient(mockConfig, mockLogger);
@@ -162,7 +164,10 @@ describe('OpaClient', () => {
       permission: { name: 'read' },
       identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
     };
-    await expect(client.evaluatePolicy(mockInput)).rejects.toThrow();
+    const mockOpaEntrypoint = 'some/admin';
+    await expect(client.evaluatePolicy(mockInput, mockOpaEntrypoint))
+        .rejects
+        .toThrow("An error response was returned after sending the policy input to the OPA server:");
   });
 
   it('should throw error when fetch throws an error', async () => {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.test.ts
@@ -147,27 +147,28 @@ describe('OpaClient', () => {
   );
 
   it('should throw an error if policyFallback is an unknown value and OPA response is not OK', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        json: jest.fn().mockResolvedValueOnce({}),
-        statusText: 'Bad Request',
-        status: 400,
-      } as any);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: jest.fn().mockResolvedValueOnce({}),
+      statusText: 'Bad Request',
+      status: 400,
+    } as any);
 
-      const mockConfigWithPolicyObject: any = structuredClone(mockConfigObject);
-      mockConfigWithPolicyObject.opaClient.policies.permissions.policyFallback = 'TEST_VALUE';
-      const mockConfigWithPolicy = new ConfigReader(mockConfigWithPolicyObject);
+    const mockConfigWithPolicyObject: any = structuredClone(mockConfigObject);
+    mockConfigWithPolicyObject.opaClient.policies.permissions.policyFallback =
+      'TEST_VALUE';
+    const mockConfigWithPolicy = new ConfigReader(mockConfigWithPolicyObject);
 
-      const client = new OpaClient(mockConfigWithPolicy, mockLogger);
-      const mockOpaEntrypoint = 'some/admin';
-      const mockInput: PolicyEvaluationInput = {
-        permission: { name: 'read' },
-        identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
-      };
-        await expect(client.evaluatePolicy(mockInput, mockOpaEntrypoint)).rejects.toThrow();
-
-    },
-  );
+    const client = new OpaClient(mockConfigWithPolicy, mockLogger);
+    const mockOpaEntrypoint = 'some/admin';
+    const mockInput: PolicyEvaluationInput = {
+      permission: { name: 'read' },
+      identity: { user: 'testUser', claims: ['claim1', 'claim2'] },
+    };
+    await expect(
+      client.evaluatePolicy(mockInput, mockOpaEntrypoint),
+    ).rejects.toThrow();
+  });
 
   it('should throw error when response is not ok', async () => {
     mockFetch.mockResolvedValueOnce({

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -91,7 +91,6 @@ export class OpaClient {
         }
         this.logger.error(message);
         throw new Error(message);
-
       }
 
       const opaPermissionsResponse =

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -107,7 +107,7 @@ export class OpaClient {
       });
       return opaPermissionsResponse.result;
     } catch (error: unknown) {
-      if (error instanceof FetchError) {
+      if (error instanceof Error && error.message === "Fetch error") {
         if (policyFallback === 'allow') {
           this.logger.warn(
             `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to allow.`,

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -1,7 +1,12 @@
 import fetch from 'node-fetch';
-import {Config} from '@backstage/config';
-import {OpaFallbackPolicy, PolicyEvaluationInput, PolicyEvaluationResponse, PolicyEvaluationResult,} from '../types';
-import {LoggerService} from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import {
+  OpaFallbackPolicy,
+  PolicyEvaluationInput,
+  PolicyEvaluationResponse,
+  PolicyEvaluationResult,
+} from '../types';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
  * OpaClient is a class responsible for interacting with the OPA server.

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -42,11 +42,10 @@ export class OpaClient {
   async evaluatePolicy(
     input: PolicyEvaluationInput,
     opaEntryPoint?: string,
-    opaPolicyFallback?: string,
   ): Promise<PolicyEvaluationResult> {
     const setEntryPoint = opaEntryPoint ?? this.opaEntryPoint;
     const opaBaseUrl = this.opaBaseUrl;
-    const policyFallback = opaPolicyFallback ?? this.opaPolicyFallback;
+    const policyFallback = this.opaPolicyFallback;
     const url = `${opaBaseUrl}/v1/data/${setEntryPoint}`;
 
     if (!opaBaseUrl) {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -112,7 +112,7 @@ export class OpaClient {
           this.logger.warn(
             `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to allow.`,
           );
-          return { result: 'ALLOW' };
+          return { result: 'ALLOW' } as PolicyEvaluationResult;
         } else if (policyFallback === 'deny') {
           this.logger.warn(
             `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to deny.`,

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -1,4 +1,4 @@
-import fetch, { FetchError } from 'node-fetch';
+import fetch from 'node-fetch';
 import { Config } from '@backstage/config';
 import {
   PolicyEvaluationInput,
@@ -37,14 +37,16 @@ export class OpaClient {
    * Evaluates a policy against a given input.
    * @param input - The input to evaluate the policy against.
    * @param opaEntryPoint - The entry point into the OPA policy to use. You can optionally provide the entry point here, otherwise it will be taken from the app-config.
+   * @param opaPolicyFallback - The fallback policy to use when the OPA server is unavailable or unresponsive. You can optionally provide the fallback policy here, otherwise it will be taken from the app-config.
    */
   async evaluatePolicy(
     input: PolicyEvaluationInput,
     opaEntryPoint?: string,
+    opaPolicyFallback?: string,
   ): Promise<PolicyEvaluationResult> {
     const setEntryPoint = opaEntryPoint ?? this.opaEntryPoint;
     const opaBaseUrl = this.opaBaseUrl;
-    const policyFallback = this.opaPolicyFallback ?? 'fail';
+    const policyFallback = opaPolicyFallback ?? this.opaPolicyFallback;
     const url = `${opaBaseUrl}/v1/data/${setEntryPoint}`;
 
     if (!opaBaseUrl) {

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -108,12 +108,12 @@ export class OpaClient {
       return opaPermissionsResponse.result;
     } catch (error: unknown) {
       if ( error instanceof Error && error.name === "FetchError" ) {
-        if (policyFallback === 'allow') {
+        if (policyFallback?.toLowerCase() === 'allow') {
           this.logger.warn(
             `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to allow.`,
           );
-          return { result: 'ALLOW' } as PolicyEvaluationResult;
-        } else if (policyFallback === 'deny') {
+          return { result: 'ALLOW' };
+        } else if (policyFallback?.toLowerCase() === 'deny') {
           this.logger.warn(
             `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to deny.`,
           );

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -107,7 +107,7 @@ export class OpaClient {
       });
       return opaPermissionsResponse.result;
     } catch (error: unknown) {
-      if (error instanceof Error && error.message === "Fetch error") {
+      if ( error instanceof Error && error.name === "FetchError" ) {
         if (policyFallback === 'allow') {
           this.logger.warn(
             `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to allow.`,

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -80,23 +80,17 @@ export class OpaClient {
       });
 
       if (!opaResponse.ok) {
-        if (policyFallback === 'allow') {
-          this.logger.warn(
-            `An error occurred while sending the policy input to the OPA server: ${opaResponse.status} - ${opaResponse.statusText}. Falling back to allow.`,
-          );
+        const message = `An error response was returned after sending the policy input to the OPA server: ${opaResponse.status} - ${opaResponse.statusText}`;
+
+        if (policyFallback?.toLowerCase() === 'allow') {
+          this.logger.warn(`${message}. Falling back to allow.`);
           return { result: 'ALLOW' };
-        } else if (policyFallback === 'deny') {
-          this.logger.warn(
-            `An error occurred while sending the policy input to the OPA server: ${opaResponse.status} - ${opaResponse.statusText}. Falling back to deny.`,
-          );
+        } else if (policyFallback?.toLowerCase() === 'deny') {
+          this.logger.warn(`${message}. Falling back to deny.`);
           return { result: 'DENY' };
         } else {
-          this.logger.error(
-            `An error occurred while sending the policy input to the OPA server: ${opaResponse.status} - ${opaResponse.statusText}`,
-          );
-          throw new Error(
-            `An error occurred while sending the policy input to the OPA server: ${opaResponse.status} - ${opaResponse.statusText}`,
-          );
+          this.logger.error(message);
+          throw new Error(message);
         }
       }
 
@@ -107,25 +101,19 @@ export class OpaClient {
       });
       return opaPermissionsResponse.result;
     } catch (error: unknown) {
-      if ( error instanceof Error && error.name === "FetchError" ) {
+      const message = `An error occurred while sending the policy input to the OPA server:`;
+
+      if (error instanceof Error && error.name === 'FetchError') {
         if (policyFallback?.toLowerCase() === 'allow') {
-          this.logger.warn(
-            `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to allow.`,
-          );
+          this.logger.warn(`${message} ${error}. Falling back to allow.`);
           return { result: 'ALLOW' };
         } else if (policyFallback?.toLowerCase() === 'deny') {
-          this.logger.warn(
-            `A network error occurred while sending the policy input to the OPA server: ${error.message}. Falling back to deny.`,
-          );
+          this.logger.warn(`${message} ${error}. Falling back to deny.`);
           return { result: 'DENY' };
         }
       }
-      this.logger.error(
-        `An error occurred while sending the policy input to the OPA server: ${error}`,
-      );
-      throw new Error(
-        `An error occurred while sending the policy input to the OPA server: ${error}`,
-      );
+      this.logger.error(`${message} ${error}`);
+      throw new Error(`${message} ${error}`);
     }
   }
 }

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -88,10 +88,10 @@ export class OpaClient {
         } else if (policyFallback?.toLowerCase() === 'deny') {
           this.logger.warn(`${message}. Falling back to deny.`);
           return { result: 'DENY' };
-        } else {
-          this.logger.error(message);
-          throw new Error(message);
         }
+        this.logger.error(message);
+        throw new Error(message);
+
       }
 
       const opaPermissionsResponse =

--- a/plugins/permission-backend-module-opa-wrapper/src/types.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/types.ts
@@ -40,3 +40,5 @@ export type PolicyEvaluationResult = {
 export type PolicyEvaluationResponse = {
   result: PolicyEvaluationResult;
 };
+
+export type OpaFallbackPolicy = 'allow' | 'deny' | undefined;


### PR DESCRIPTION
<!--
Before submitting your pull request, please ensure you've done the following:
- [X] Reviewed the guidelines for contributing to this repository.
- [X] Checked for duplicate pull requests that might already be open.
- [ X] Used clear, concise and meaningful commit messages.
- [ ] Updated any relevant documentation.
-->

## What type of PR is this?

Please check the category that applies:

- [X] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

## Description

Adds a failover mechanism to the wrapper plugin in the case of a failed connection with the OPA server.

### Additional changes

- Fixed some opaClient tests that weren't actually covering the intended lines they were meant to cover
- Added documentation for this change

## Related Issues

If applicable, please link any related issues. Use "Closes" keyword to automatically close the issue on PR merge.

Closes #218 

## Testing

- [X] I have included or updated unit tests for my changes.
- [ ] I would like some help writing tests.
- [ ] These changes do not require tests.
