### PR TITLE
update: overload evaluatePolicy in order to get custom return type

### DIFF
--- a/.changeset/khaki-drinks-vanish.md
+++ b/.changeset/khaki-drinks-vanish.md
@@ -1,0 +1,5 @@
+---
+'@parsifal-m/plugin-permission-backend-module-opa-wrapper': patch
+---
+
+overloaded evaluatePolicy in order to change the return type

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -130,12 +130,12 @@ export class OpaClient {
   /**
    * Overloaded function signatures for evaluatePolicy.
    */
-  async evaluatePolicy<T>(input: PolicyInput, entryPoint: string): Promise<T>;
   async evaluatePolicy(
     input: PolicyInput,
     entryPoint: string,
   ): Promise<PolicyResult>;
-
+  async evaluatePolicy<T>(input: PolicyInput, entryPoint: string): Promise<T>;
+  
   /**
    * Evaluates a generic policy by sending the input to the OPA server and returns the result.
    *

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -135,7 +135,7 @@ export class OpaClient {
     entryPoint: string,
   ): Promise<PolicyResult>;
   async evaluatePolicy<T>(input: PolicyInput, entryPoint: string): Promise<T>;
-  
+
   /**
    * Evaluates a generic policy by sending the input to the OPA server and returns the result.
    *

--- a/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/opa-client/opaClient.ts
@@ -128,6 +128,15 @@ export class OpaClient {
   }
 
   /**
+   * Overloaded function signatures for evaluatePolicy.
+   */
+  async evaluatePolicy<T>(input: PolicyInput, entryPoint: string): Promise<T>;
+  async evaluatePolicy(
+    input: PolicyInput,
+    entryPoint: string,
+  ): Promise<PolicyResult>;
+
+  /**
    * Evaluates a generic policy by sending the input to the OPA server and returns the result.
    *
    * @param input - The policy input to be evaluated.
@@ -135,10 +144,10 @@ export class OpaClient {
    * @returns A promise that resolves to the policy result.
    * @throws An error if the OPA server returns a non-OK response or if there is an issue with the request.
    */
-  async evaluatePolicy(
+  async evaluatePolicy<T = PolicyResult>(
     input: PolicyInput,
     entryPoint: string,
-  ): Promise<PolicyResult> {
+  ): Promise<T> {
     const url = `${this.baseUrl}/v1/data/${entryPoint}`;
 
     this.logger.debug(
@@ -160,7 +169,7 @@ export class OpaClient {
         throw new Error(message);
       }
 
-      const opaPermissionsResponse = (await opaResponse.json()) as PolicyResult;
+      const opaPermissionsResponse = (await opaResponse.json()) as T;
 
       this.logger.debug(
         `Received data from OPA: ${JSON.stringify(opaPermissionsResponse)}`,


### PR DESCRIPTION
# 👋 Thanks for contributing

## What's this PR about?

<!-- Please give us a brief description of what you're working on -->

### Type of change

- [ ] 🌟 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [x] 🧹 Code cleanup/refactor

### What does it solve?
I'm fairly new to OPA but looks like the response from the OPA server can look fairly different, so I thought it would be reasonable to be able to pass in the type yourself. What do you think?

### Testing

- [ ] Added/updated tests
- [ ] Need help with testing
- [x] N/A - documentation only

### Related issues

<!-- Example: Closes #123 -->

---
Need any help? Feel free to ask questions in your PR! 💬
