### PR TITLE
Fix: should be NOT and not NONE

### DIFF
--- a/.changeset/unlucky-kings-live.md
+++ b/.changeset/unlucky-kings-live.md
@@ -1,0 +1,5 @@
+---
+'@parsifal-m/plugin-permission-backend-module-opa-wrapper': patch
+---
+
+`none` was not accepted by the permissions framework and should be `not` updated the types to accept `not`

--- a/plugins/permission-backend-module-opa-wrapper/src/types.ts
+++ b/plugins/permission-backend-module-opa-wrapper/src/types.ts
@@ -70,7 +70,7 @@ export type PermissionsFrameworkPolicyEvaluationResult = {
       resourceType: string;
       rule: string;
     }[];
-    none?: {
+    not?: {
       params: {
         [key: string]: any;
       };


### PR DESCRIPTION
# 👋 Thanks for contributing

## What's this PR about?

Not sure how or where I got the `none` from, but it should be `not`

### Type of change

- [ ] 🌟 New feature
- [x] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🧹 Code cleanup/refactor

### What does it solve?

Now can use `not` in policy conditionals as `none` was not accepted by the permissions framework

### Testing

- [ ] Added/updated tests
- [ ] Need help with testing
- [ ] N/A - documentation only

### Related issues

N/A

---
Need any help? Feel free to ask questions in your PR! 💬
