### PR TITLE
Custom route for backstage backend for backstage-plugin-opa-authz-react and manually triggerable hook

### DIFF
--- a/plugins/backstage-plugin-opa-authz-react/src/api/api.ts
+++ b/plugins/backstage-plugin-opa-authz-react/src/api/api.ts
@@ -1,4 +1,4 @@
-import { ApiRef, createApiRef, FetchApi } from '@backstage/core-plugin-api';
+import { ApiRef, createApiRef, FetchApi, ConfigApi } from '@backstage/core-plugin-api';
 import { OpaAuthzApi, PolicyInput, PolicyResult } from './types';
 
 export const opaAuthzBackendApiRef: ApiRef<OpaAuthzApi> =
@@ -8,15 +8,17 @@ export const opaAuthzBackendApiRef: ApiRef<OpaAuthzApi> =
 
 export class OpaAuthzClientReact implements OpaAuthzApi {
   private readonly fetchApi: FetchApi;
-  constructor(options: { fetchApi: FetchApi }) {
+  private readonly configApi?: ConfigApi;
+  constructor(options: { fetchApi: FetchApi, configApi?: ConfigApi }) {
     this.fetchApi = options.fetchApi;
+    this.configApi = options.configApi;
   }
 
   async evalPolicy(
     input: PolicyInput,
     entryPoint: string,
   ): Promise<PolicyResult> {
-    const url = `plugin://opa/opa-authz`;
+    const url = this.configApi?.getOptionalString('opaClient.backstageUrl') || `plugin://opa/opa-authz`;
 
     const response = await this.fetchApi.fetch(url, {
       method: 'POST',

--- a/plugins/backstage-plugin-opa-authz-react/src/hooks/useOpaAuthz/index.ts
+++ b/plugins/backstage-plugin-opa-authz-react/src/hooks/useOpaAuthz/index.ts
@@ -1,1 +1,1 @@
-export { useOpaAuthz } from './useOpaAuthz';
+export { useOpaAuthz, useOpaAuthzManual } from './useOpaAuthz';

--- a/plugins/backstage-plugin-opa-authz-react/src/hooks/useOpaAuthz/useOpaAuthz.test.ts
+++ b/plugins/backstage-plugin-opa-authz-react/src/hooks/useOpaAuthz/useOpaAuthz.test.ts
@@ -1,5 +1,5 @@
 import { waitFor, renderHook } from '@testing-library/react';
-import { useOpaAuthz } from './useOpaAuthz';
+import { useOpaAuthz, useOpaAuthzManual } from './useOpaAuthz';
 import { useApi } from '@backstage/core-plugin-api';
 import { OpaAuthzApi } from '../../api';
 
@@ -27,5 +27,62 @@ describe('useOpaAuthz', () => {
     await waitFor(() => result.current.data !== null);
 
     expect(result.current.data).toEqual({ result: { allow: true } });
+  });
+});
+
+describe('useOpaAuthzManual', () => {
+  const mockEvalPolicy = jest.fn();
+
+  beforeEach(() => {
+    mockEvalPolicy.mockClear();
+    (useApi as jest.Mock).mockReturnValue({
+      evalPolicy: mockEvalPolicy,
+    } as unknown as OpaAuthzApi);
+  });
+
+  it('should not fetch data initially', () => {
+    mockEvalPolicy.mockResolvedValue({ result: { allow: true } });
+
+    const { result } = renderHook(() =>
+      useOpaAuthzManual({ entity: 'test' }, 'test'),
+    );
+
+    expect(mockEvalPolicy).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('should fetch data when triggerFetch is called', async () => {
+    mockEvalPolicy.mockResolvedValue({ result: { allow: true } });
+
+    const { result } = renderHook(() =>
+      useOpaAuthzManual({ entity: 'test' }, 'test'),
+    );
+
+    expect(mockEvalPolicy).not.toHaveBeenCalled();
+
+    await result.current.triggerFetch();
+
+    await waitFor(() => result.current.data !== null);
+
+    expect(mockEvalPolicy).toHaveBeenCalledWith({ entity: 'test' }, 'test');
+    expect(result.current.data).toEqual({ result: { allow: true } });
+  });
+
+  it('should handle errors when fetching', async () => {
+    const error = new Error('Test error');
+    mockEvalPolicy.mockRejectedValue(error);
+
+    const { result } = renderHook(() =>
+      useOpaAuthzManual({ entity: 'test' }, 'test'),
+    );
+
+    await result.current.triggerFetch();
+
+    await waitFor(() => result.current.error !== undefined);
+
+    expect(result.current.error).toBe(error);
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
   });
 });


### PR DESCRIPTION
# 👋 Thanks for contributing

## What's this PR about?

<!-- Please give us a brief description of what you're working on -->

### Type of change

- [x] 🌟 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🧹 Code cleanup/refactor

### What does it solve?

When using this hook there might be the case that you have to wait for information in order to pass that info to the OPA server, therefore I added a hook which can be triggered manually

When using this frontend plugin you are forced to create a backend plugin with plugin id opa. In my case that diverts from our naming standard. It would be more flexible if you can just specify the route in the app.config file and then that will be used

### Testing

- [x] Added/updated tests
- [ ] Need help with testing
- [ ] N/A - documentation only

### Related issues


---
Need any help? Feel free to ask questions in your PR! 💬
