### PR TITLE
Fix: Don't throw an error if the config is not provided for the Entity Checker in the OPA Backend

### DIFF
--- a/.changeset/hungry-suns-clean.md
+++ b/.changeset/hungry-suns-clean.md
@@ -1,0 +1,5 @@
+---
+'@parsifal-m/plugin-opa-backend': minor
+---
+
+No longer throws an error if the EntityChecker config is not set, instead log an error

--- a/plugins/backstage-opa-backend/src/api/EntityCheckerApi.test.ts
+++ b/plugins/backstage-opa-backend/src/api/EntityCheckerApi.test.ts
@@ -28,7 +28,7 @@ describe('EntityCheckerApiImpl', () => {
     );
   });
 
-  it('should log error when entityCheckerEntrypoint is missing', () => {
+  it('should log error when opaClient.policies.entityChecker.entryPoint (entityCheckerEntrypoint) is missing', () => {
     const config: EntityCheckerConfig = {
       logger: mockLogger,
       opaBaseUrl: 'http://localhost:8181',

--- a/plugins/backstage-opa-backend/src/api/EntityCheckerApi.test.ts
+++ b/plugins/backstage-opa-backend/src/api/EntityCheckerApi.test.ts
@@ -24,7 +24,7 @@ describe('EntityCheckerApiImpl', () => {
     const _api = new EntityCheckerApiImpl(config);
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'OPA URL not set or missing!',
+      'OPA base url not set or missing!',
     );
   });
 
@@ -38,7 +38,7 @@ describe('EntityCheckerApiImpl', () => {
     const _api = new EntityCheckerApiImpl(config);
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'OPA package not set or missing!',
+      'OPA entity checker entry point not set or missing!',
     );
   });
 
@@ -52,10 +52,10 @@ describe('EntityCheckerApiImpl', () => {
     const _api = new EntityCheckerApiImpl(config);
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'OPA URL not set or missing!',
+      'OPA base url not set or missing!',
     );
     expect(mockLogger.error).toHaveBeenCalledWith(
-      'OPA package not set or missing!',
+      'OPA entity checker entry point not set or missing!',
     );
     expect(mockLogger.error).toHaveBeenCalledTimes(2);
   });

--- a/plugins/backstage-opa-backend/src/api/EntityCheckerApi.ts
+++ b/plugins/backstage-opa-backend/src/api/EntityCheckerApi.ts
@@ -62,12 +62,10 @@ export class EntityCheckerApiImpl implements EntityCheckerApi {
 
     if (!config.opaBaseUrl) {
       logger.error('OPA URL not set or missing!');
-      throw new Error('OPA URL not set or missing!');
     }
 
     if (!config.entityCheckerEntrypoint) {
       logger.error('OPA package not set or missing!');
-      throw new Error('OPA package not set or missing!');
     }
   }
 

--- a/plugins/backstage-opa-backend/src/api/EntityCheckerApi.ts
+++ b/plugins/backstage-opa-backend/src/api/EntityCheckerApi.ts
@@ -61,11 +61,11 @@ export class EntityCheckerApiImpl implements EntityCheckerApi {
     const logger = this.config.logger;
 
     if (!config.opaBaseUrl) {
-      logger.error('OPA URL not set or missing!');
+      logger.error('OPA base url not set or missing!');
     }
 
     if (!config.entityCheckerEntrypoint) {
-      logger.error('OPA package not set or missing!');
+      logger.error('OPA entity checker entry point not set or missing!');
     }
   }
 


### PR DESCRIPTION
# 👋 Thanks for contributing

## What's this PR about?

Over time the OPA backend has grown to do a lot of independent OPA things, some you may not use, so making the config optional then throwing an error when not provided is a bit illogical.

This is a step to improve this.

### Type of change

- [ ] 🌟 New feature
- [x] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🧹 Code cleanup/refactor

### What does it solve?

If you don't use some of the frontend plugins or other features that consume the backend plugin, we shouldn't throw errors if that config is not provided.

### Testing

- [x] Added/updated tests
- [ ] Need help with testing
- [ ] N/A - documentation only

### Related issues

Partly solves some of the issues in #281 

---
Need any help? Feel free to ask questions in your PR! 💬
