### PR TITLE
adds local dev setup, and removes core-app dependency on the opa-backend

### DIFF
--- a/.changeset/wet-steaks-visit.md
+++ b/.changeset/wet-steaks-visit.md
@@ -1,0 +1,5 @@
+---
+'@parsifal-m/plugin-opa-backend': minor
+---
+
+Update to use the `catalogServiceRef` instead of the `CatalogClient`

--- a/.changeset/wet-steaks-visit.md
+++ b/.changeset/wet-steaks-visit.md
@@ -1,5 +1,5 @@
 ---
-'@parsifal-m/plugin-opa-backend': minor
+'@parsifal-m/plugin-opa-backend': major
 ---
 
 Update to use the `catalogServiceRef` instead of the `CatalogClient`

--- a/.changeset/wet-steaks-visit.md
+++ b/.changeset/wet-steaks-visit.md
@@ -2,4 +2,10 @@
 '@parsifal-m/plugin-opa-backend': major
 ---
 
-Update to use the `catalogServiceRef` instead of the `CatalogClient`
+Refactors the OPA backend plugin internals:
+
+- Replaces `CatalogClient` with `catalogServiceRef` — the plugin now uses the Backstage catalog service directly rather than making HTTP calls to the catalog API
+- Removes `auth` from `RouterOptions` and the `authzRouter` signature — no longer needed now that `CatalogService` accepts credentials directly
+- Renames `catalogApi` to `catalog` in `RouterOptions` — consumers constructing the router directly must update accordingly
+- Adds Zod validation on the `/opa-authz` request body — invalid requests now return a structured 400 with field-level errors
+- Strips `userEntity` from caller-supplied input before forwarding to OPA — prevents clients from spoofing identity fields in policy evaluation

--- a/opa-docs/docs/opa-backend/local-development.md
+++ b/opa-docs/docs/opa-backend/local-development.md
@@ -1,0 +1,118 @@
+# Local Development
+
+The OPA Backend plugin has a self-contained dev setup that lets you run and test it in isolation — no full Backstage app required.
+
+## Prerequisites
+
+- Node 22 or 24
+- A running OPA server at `http://localhost:8181` — run `docker-compose up -d` from the repo root
+- Dependencies installed: `yarn install --immutable`
+
+## Starting the plugin
+
+```bash
+yarn workspace @parsifal-m/plugin-opa-backend start
+```
+
+The backend starts at `http://localhost:7007`. All routes are mounted under `/api/opa`.
+
+The dev setup uses mocked Backstage services (`auth`, `httpAuth`, `userInfo`) so no real Backstage instance or database is needed. OPA itself must still be running for any route that evaluates a policy.
+
+## Mock authentication
+
+The dev backend uses `mockServices.httpAuth` and `mockServices.userInfo`, both permissive by design. Requests without an `Authorization` header succeed, and OPA always receives the same mock identity regardless of which token you pass:
+
+```json
+{
+  "userEntityRef": "user:default/mock",
+  "ownershipEntityRefs": ["user:default/mock"]
+}
+```
+
+No auth header needed when testing locally.
+
+## Testing the routes
+
+### Health check
+
+```bash
+curl http://localhost:7007/api/opa/health
+```
+
+Expected response:
+
+```json
+{ "status": "ok" }
+```
+
+---
+
+### POST /api/opa/opa-authz
+
+Evaluates an OPA policy.
+
+```bash
+curl -X POST http://localhost:7007/api/opa/opa-authz \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "entryPoint": "opa_demo/allow",
+    "input": {
+      "method": "GET",
+      "permission": { "name": "read-all-todos" }
+    }
+  }'
+```
+
+Expected response (policy returns `true` for this input — no ownership check on this rule):
+
+```json
+{ "result": true }
+```
+
+The plugin automatically merges `userEntityRef` and `ownershipEntityRefs` from the mock user into `input` before forwarding to OPA. See the [reference](./reference.md#post-apiopaopa-authz) for the full list of auto-injected fields.
+
+To also include the full user entity, set `includeUserEntity: true`. The dev setup includes a mock `User` entity for `user:default/mock` in the catalog, so this resolves without needing a real catalog:
+
+```bash
+curl -X POST http://localhost:7007/api/opa/opa-authz \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "entryPoint": "opa_demo/allow",
+    "input": {
+      "method": "GET",
+      "permission": { "name": "read-all-todos" }
+    },
+    "includeUserEntity": true
+  }'
+```
+
+OPA will receive the full entity including annotations like `company.com/role`, `company.com/department`, and `company.com/team` — useful for writing policies that gate on role or other annotations. To change the mock user entity, edit `dev/index.ts`.
+
+---
+
+### POST /api/opa/entity-checker
+
+Requires `openPolicyAgent.entityChecker.enabled: true` and `openPolicyAgent.entityChecker.policyEntryPoint` set in `app-config.yaml`.
+
+```bash
+curl -X POST http://localhost:7007/api/opa/entity-checker \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "input": {
+      "apiVersion": "backstage.io/v1alpha1",
+      "kind": "Component",
+      "metadata": { "name": "sample", "namespace": "default" },
+      "spec": { "type": "service", "lifecycle": "production" }
+    }
+  }'
+```
+
+---
+
+### GET /api/opa/get-policy
+
+Requires `openPolicyAgent.policyViewer.enabled: true`.
+
+```bash
+curl "http://localhost:7007/api/opa/get-policy?opaPolicy=https://raw.githubusercontent.com/your-org/your-repo/main/policies/my_policy.rego"
+```

--- a/opa-docs/docs/opa-backend/reference.md
+++ b/opa-docs/docs/opa-backend/reference.md
@@ -70,10 +70,10 @@ Evaluates an OPA policy and returns the result. Used by [`opa-authz-react`](../o
 
 The plugin automatically adds the following to `input` before forwarding to OPA, regardless of what the caller sends:
 
-| Field                 | Type             | Description                                                                |
-| --------------------- | ---------------- | -------------------------------------------------------------------------- |
-| `userEntityRef`       | `string`         | Backstage entity ref of the calling user (e.g. `user:default/jane`).       |
-| `ownershipEntityRefs` | `string[]`       | All entity refs the user owns.                                             |
+| Field                 | Type             | Description                                                                                                                                                                                    |
+| --------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `userEntityRef`       | `string`         | Backstage entity ref of the calling user (e.g. `user:default/jane`).                                                                                                                           |
+| `ownershipEntityRefs` | `string[]`       | All entity refs the user owns.                                                                                                                                                                 |
 | `userEntity`          | `Entity \| null` | Full Backstage `User` entity resolved from the catalog. Only present when `includeUserEntity: true`. Always set by the backend — any `userEntity` supplied by the caller is silently stripped. |
 
 **Response**

--- a/opa-docs/docs/opa-backend/reference.md
+++ b/opa-docs/docs/opa-backend/reference.md
@@ -82,10 +82,10 @@ The raw response body from OPA's `/v1/data/<entryPoint>` endpoint, passed throug
 
 **Error responses**
 
-| Status | Cause                                                               |
-| ------ | ------------------------------------------------------------------- |
-| `400`  | Missing `input` or `entryPoint` in request body.                    |
-| `500`  | OPA server unreachable, or error fetching user entity from catalog. |
+| Status | Cause                                                                                                                                    |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | Request body failed schema validation. Response includes `error: "Invalid request body"` and a `details` object with field-level errors. |
+| `500`  | OPA server unreachable, or error fetching user entity from catalog.                                                                      |
 
 ---
 

--- a/opa-docs/docs/opa-backend/reference.md
+++ b/opa-docs/docs/opa-backend/reference.md
@@ -82,10 +82,10 @@ The raw response body from OPA's `/v1/data/<entryPoint>` endpoint, passed throug
 
 **Error responses**
 
-| Status | Cause                                                                                                                                    |
-| ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `400`  | Request body failed schema validation. Response includes `error: "Invalid request body"` and a `details` object with field-level errors. |
-| `500`  | OPA server unreachable, or error fetching user entity from catalog.                                                                      |
+| Status | Cause                                                                                                                                                                        |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | Request body failed schema validation. Response includes `error: "Invalid request body"` and a `details` object with `formErrors` (top-level) and `fieldErrors` (per-field). |
+| `500`  | OPA server unreachable, or error fetching user entity from catalog.                                                                                                          |
 
 ---
 

--- a/opa-docs/docs/opa-backend/reference.md
+++ b/opa-docs/docs/opa-backend/reference.md
@@ -74,7 +74,7 @@ The plugin automatically adds the following to `input` before forwarding to OPA,
 | --------------------- | ---------------- | -------------------------------------------------------------------------- |
 | `userEntityRef`       | `string`         | Backstage entity ref of the calling user (e.g. `user:default/jane`).       |
 | `ownershipEntityRefs` | `string[]`       | All entity refs the user owns.                                             |
-| `userEntity`          | `Entity \| null` | Full Backstage `User` entity. Only present when `includeUserEntity: true`. |
+| `userEntity`          | `Entity \| null` | Full Backstage `User` entity resolved from the catalog. Only present when `includeUserEntity: true`. Always set by the backend — any `userEntity` supplied by the caller is silently stripped. |
 
 **Response**
 

--- a/opa-docs/sidebars.ts
+++ b/opa-docs/sidebars.ts
@@ -30,7 +30,11 @@ const sidebars: SidebarsConfig = {
         type: 'doc',
         id: 'opa-backend/introduction',
       },
-      items: ['opa-backend/quick-start', 'opa-backend/reference'],
+      items: [
+        'opa-backend/quick-start',
+        'opa-backend/reference',
+        'opa-backend/local-development',
+      ],
     },
     {
       type: 'category',

--- a/plugins/backstage-opa-backend/dev/index.ts
+++ b/plugins/backstage-opa-backend/dev/index.ts
@@ -23,7 +23,7 @@ import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 // Entity checker (requires openPolicyAgent.entityChecker.enabled: true in app-config.yaml):
 //   curl -X POST http://localhost:7007/api/opa/entity-checker \
 //     -H 'Content-Type: application/json' \
-//     -d '{"entity": {"apiVersion": "backstage.io/v1alpha1", "kind": "Component", "metadata": {"name": "sample"}, "spec": {}}}'
+//     -d '{"input": {"apiVersion": "backstage.io/v1alpha1", "kind": "Component", "metadata": {"name": "sample"}, "spec": {}}}'
 
 const backend = createBackend();
 

--- a/plugins/backstage-opa-backend/dev/index.ts
+++ b/plugins/backstage-opa-backend/dev/index.ts
@@ -1,0 +1,76 @@
+import { createBackend } from '@backstage/backend-defaults';
+import { mockServices } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+
+// Minimal dev backend for @parsifal-m/plugin-opa-backend
+// Requires a running OPA server at http://localhost:8181 for policy evaluation.
+//
+// Start: yarn start (from this plugin directory)
+//
+// Health check:
+//   curl http://localhost:7007/api/opa/health
+//
+// Authz:
+//   curl -X POST http://localhost:7007/api/opa/opa-authz \
+//     -H 'Content-Type: application/json' \
+//     -d '{"input": {"action": "read"}, "entryPoint": "my_policy/decision"}'
+//
+// Authz with full user entity (resolves user:default/mock from catalog mock):
+//   curl -X POST http://localhost:7007/api/opa/opa-authz \
+//     -H 'Content-Type: application/json' \
+//     -d '{"input": {"action": "read"}, "entryPoint": "my_policy/decision", "includeUserEntity": true}'
+//
+// Entity checker (requires openPolicyAgent.entityChecker.enabled: true in app-config.yaml):
+//   curl -X POST http://localhost:7007/api/opa/entity-checker \
+//     -H 'Content-Type: application/json' \
+//     -d '{"entity": {"apiVersion": "backstage.io/v1alpha1", "kind": "Component", "metadata": {"name": "sample"}, "spec": {}}}'
+
+const backend = createBackend();
+
+backend.add(mockServices.auth.factory());
+backend.add(mockServices.httpAuth.factory());
+backend.add(mockServices.userInfo.factory());
+
+backend.add(
+  catalogServiceMock.factory({
+    entities: [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: {
+          name: 'mock',
+          namespace: 'default',
+          annotations: {
+            'company.com/role': 'developer',
+            'company.com/department': 'engineering',
+            'company.com/team': 'platform',
+          },
+        },
+        spec: {
+          profile: {
+            displayName: 'Mock User',
+            email: 'mock@example.com',
+          },
+          memberOf: ['group:default/team-a'],
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'sample',
+          title: 'Sample Component',
+          namespace: 'default',
+        },
+        spec: {
+          type: 'service',
+          owner: 'user:default/mock',
+        },
+      },
+    ],
+  }),
+);
+
+backend.add(import('../src'));
+
+backend.start();

--- a/plugins/backstage-opa-backend/package.json
+++ b/plugins/backstage-opa-backend/package.json
@@ -53,7 +53,8 @@
     "express-promise-router": "^4.1.0",
     "knex": "^3.1.0",
     "node-fetch": "^2.6.7",
-    "yn": "^4.0.0"
+    "yn": "^4.0.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "backstage:^",

--- a/plugins/backstage-opa-backend/src/plugin.ts
+++ b/plugins/backstage-opa-backend/src/plugin.ts
@@ -2,7 +2,7 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
-import { CatalogClient } from '@backstage/catalog-client';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { createRouter } from './service';
 
 export const opaPlugin = createBackendPlugin({
@@ -11,8 +11,8 @@ export const opaPlugin = createBackendPlugin({
     env.registerInit({
       deps: {
         auth: coreServices.auth,
+        catalog: catalogServiceRef,
         config: coreServices.rootConfig,
-        discovery: coreServices.discovery,
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
         httpAuth: coreServices.httpAuth,
@@ -21,8 +21,8 @@ export const opaPlugin = createBackendPlugin({
       },
       async init({
         auth,
+        catalog,
         config,
-        discovery,
         logger,
         httpRouter,
         httpAuth,
@@ -32,7 +32,7 @@ export const opaPlugin = createBackendPlugin({
         httpRouter.use(
           await createRouter({
             auth,
-            catalogApi: new CatalogClient({ discoveryApi: discovery }),
+            catalog,
             config,
             logger,
             httpAuth,

--- a/plugins/backstage-opa-backend/src/plugin.ts
+++ b/plugins/backstage-opa-backend/src/plugin.ts
@@ -10,7 +10,6 @@ export const opaPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        auth: coreServices.auth,
         catalog: catalogServiceRef,
         config: coreServices.rootConfig,
         logger: coreServices.logger,
@@ -20,7 +19,6 @@ export const opaPlugin = createBackendPlugin({
         userInfo: coreServices.userInfo,
       },
       async init({
-        auth,
         catalog,
         config,
         logger,
@@ -31,7 +29,6 @@ export const opaPlugin = createBackendPlugin({
       }) {
         httpRouter.use(
           await createRouter({
-            auth,
             catalog,
             config,
             logger,

--- a/plugins/backstage-opa-backend/src/service/router.test.ts
+++ b/plugins/backstage-opa-backend/src/service/router.test.ts
@@ -17,7 +17,7 @@ describe('createRouter', () => {
     });
     const router = await createRouter({
       auth: mockServices.auth.mock(),
-      catalogApi: catalogServiceMock.mock(),
+      catalog: catalogServiceMock.mock(),
       config: mockConfig,
       logger: mockServices.logger.mock(),
       urlReader: mockServices.urlReader.mock(),

--- a/plugins/backstage-opa-backend/src/service/router.test.ts
+++ b/plugins/backstage-opa-backend/src/service/router.test.ts
@@ -16,7 +16,6 @@ describe('createRouter', () => {
       },
     });
     const router = await createRouter({
-      auth: mockServices.auth.mock(),
       catalog: catalogServiceMock.mock(),
       config: mockConfig,
       logger: mockServices.logger.mock(),

--- a/plugins/backstage-opa-backend/src/service/router.ts
+++ b/plugins/backstage-opa-backend/src/service/router.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import Router from 'express-promise-router';
 import {
-  AuthService,
   HttpAuthService,
   LoggerService,
   UrlReaderService,
@@ -15,7 +14,6 @@ import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 
 export type RouterOptions = {
-  auth: AuthService;
   catalog: CatalogService;
   logger: LoggerService;
   config: Config;
@@ -27,8 +25,7 @@ export type RouterOptions = {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { auth, catalog, logger, config, urlReader, httpAuth, userInfo } =
-    options;
+  const { catalog, logger, config, urlReader, httpAuth, userInfo } = options;
 
   const router = Router();
   router.use(express.json());
@@ -53,7 +50,7 @@ export async function createRouter(
     router.use(policyViewerRouter(logger, urlReader));
   }
 
-  router.use(authzRouter(auth, catalog, logger, config, httpAuth, userInfo));
+  router.use(authzRouter(catalog, logger, config, httpAuth, userInfo));
 
   const middleware = MiddlewareFactory.create({ logger, config });
 

--- a/plugins/backstage-opa-backend/src/service/router.ts
+++ b/plugins/backstage-opa-backend/src/service/router.ts
@@ -12,11 +12,11 @@ import { policyViewerRouter } from './routers/policyViewer';
 import { authzRouter } from './routers/authz';
 import { Config } from '@backstage/config';
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
-import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogService } from '@backstage/plugin-catalog-node';
 
 export type RouterOptions = {
   auth: AuthService;
-  catalogApi: CatalogApi;
+  catalog: CatalogService;
   logger: LoggerService;
   config: Config;
   urlReader: UrlReaderService;
@@ -27,7 +27,7 @@ export type RouterOptions = {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { auth, catalogApi, logger, config, urlReader, httpAuth, userInfo } =
+  const { auth, catalog, logger, config, urlReader, httpAuth, userInfo } =
     options;
 
   const router = Router();
@@ -53,7 +53,7 @@ export async function createRouter(
     router.use(policyViewerRouter(logger, urlReader));
   }
 
-  router.use(authzRouter(auth, catalogApi, logger, config, httpAuth, userInfo));
+  router.use(authzRouter(auth, catalog, logger, config, httpAuth, userInfo));
 
   const middleware = MiddlewareFactory.create({ logger, config });
 

--- a/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
@@ -28,6 +28,7 @@ describe('authzRouter', () => {
       user: 'testUser',
       email: 'test@example.com',
       userEntityRef: 'user:default/testUser',
+      ownershipEntityRefs: ['user:default/testUser', 'group:default/team-a'],
     };
 
     mockUserInfo.getUserInfo.mockResolvedValue(
@@ -56,7 +57,7 @@ describe('authzRouter', () => {
   });
 
   describe('POST /opa-authz', () => {
-    it('returns 400 if input or entryPoint is missing', async () => {
+    it('returns 400 for invalid request body', async () => {
       const { app } = buildApp();
       const res = await request(app).post('/opa-authz').send({});
 
@@ -94,6 +95,10 @@ describe('authzRouter', () => {
               user: 'testUser',
               email: 'test@example.com',
               userEntityRef: 'user:default/testUser',
+              ownershipEntityRefs: [
+                'user:default/testUser',
+                'group:default/team-a',
+              ],
             },
           }),
         }),
@@ -125,6 +130,10 @@ describe('authzRouter', () => {
               user: 'testUser',
               email: 'test@example.com',
               userEntityRef: 'user:default/testUser',
+              ownershipEntityRefs: [
+                'user:default/testUser',
+                'group:default/team-a',
+              ],
             },
           }),
         }),
@@ -172,6 +181,10 @@ describe('authzRouter', () => {
               user: 'testUser',
               email: 'test@example.com',
               userEntityRef: 'user:default/testUser',
+              ownershipEntityRefs: [
+                'user:default/testUser',
+                'group:default/team-a',
+              ],
               userEntity: fakeEntity,
             },
           }),
@@ -227,6 +240,10 @@ describe('authzRouter', () => {
               user: 'testUser',
               email: 'test@example.com',
               userEntityRef: 'user:default/testUser',
+              ownershipEntityRefs: [
+                'user:default/testUser',
+                'group:default/team-a',
+              ],
             },
           }),
         }),

--- a/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
@@ -25,7 +25,7 @@ describe('authzRouter', () => {
       }),
     });
 
-    const mockCatalogApi = catalogServiceMock.mock();
+    const mockCatalog = catalogServiceMock.mock();
     const mockLogger = mockServices.logger.mock();
     const mockHttpAuth = mockServices.httpAuth.mock();
     const mockUserInfo = mockServices.userInfo.mock();
@@ -42,7 +42,7 @@ describe('authzRouter', () => {
 
     const router = authzRouter(
       mockAuth,
-      mockCatalogApi,
+      mockCatalog,
       mockLogger,
       config,
       mockHttpAuth,
@@ -53,7 +53,7 @@ describe('authzRouter', () => {
 
     return {
       app,
-      mockCatalogApi,
+      mockCatalog,
       mockUserInfo,
     };
   };
@@ -141,7 +141,7 @@ describe('authzRouter', () => {
     });
 
     it('includes full user entity when requested in body', async () => {
-      const { app, mockCatalogApi } = buildApp();
+      const { app, mockCatalog } = buildApp();
 
       const fakeEntity = {
         apiVersion: 'backstage.io/v1alpha1',
@@ -150,7 +150,7 @@ describe('authzRouter', () => {
         spec: {},
       };
 
-      mockCatalogApi.getEntityByRef.mockResolvedValue(fakeEntity);
+      mockCatalog.getEntityByRef.mockResolvedValue(fakeEntity);
 
       (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
         new Response(JSON.stringify({ result: { allow: true } }), {
@@ -166,7 +166,7 @@ describe('authzRouter', () => {
           includeUserEntity: true,
         });
 
-      expect(mockCatalogApi.getEntityByRef).toHaveBeenCalledWith(
+      expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
         'user:default/testUser',
         expect.any(Object),
       );
@@ -189,7 +189,7 @@ describe('authzRouter', () => {
     });
 
     it('does NOT include full user entity when not requested', async () => {
-      const { app, mockCatalogApi } = buildApp();
+      const { app, mockCatalog } = buildApp();
 
       (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
         new Response(JSON.stringify({ result: { allow: true } }), {
@@ -204,7 +204,7 @@ describe('authzRouter', () => {
           entryPoint: 'testEntryPoint',
         });
 
-      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+      expect(mockCatalog.getEntityByRef).not.toHaveBeenCalled();
     });
   });
 });

--- a/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
@@ -19,12 +19,6 @@ describe('authzRouter', () => {
       },
     });
 
-    const mockAuth = mockServices.auth.mock({
-      getPluginRequestToken: jest.fn().mockResolvedValue({
-        token: 'fake-token',
-      }),
-    });
-
     const mockCatalog = catalogServiceMock.mock();
     const mockLogger = mockServices.logger.mock();
     const mockHttpAuth = mockServices.httpAuth.mock();
@@ -41,7 +35,6 @@ describe('authzRouter', () => {
     );
 
     const router = authzRouter(
-      mockAuth,
       mockCatalog,
       mockLogger,
       config,

--- a/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.test.ts
@@ -61,9 +61,7 @@ describe('authzRouter', () => {
       const res = await request(app).post('/opa-authz').send({});
 
       expect(res.status).toEqual(400);
-      expect(res.body).toEqual({
-        error: 'Missing input or entryPoint in request body',
-      });
+      expect(res.body).toMatchObject({ error: 'Invalid request body' });
     });
 
     it('returns the policy evaluation result', async () => {
@@ -198,6 +196,41 @@ describe('authzRouter', () => {
         });
 
       expect(mockCatalog.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('strips userEntity from caller input — userEntity is backend-owned', async () => {
+      const { app } = buildApp();
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
+        new Response(JSON.stringify({ result: { allow: true } }), {
+          status: 200,
+        }),
+      );
+
+      await request(app)
+        .post('/opa-authz')
+        .send({
+          input: {
+            user: 'testUser',
+            userEntity: {
+              metadata: { annotations: { 'company.com/role': 'admin' } },
+            },
+          },
+          entryPoint: 'testEntryPoint',
+        });
+
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:8181/v1/data/testEntryPoint',
+        expect.objectContaining({
+          body: JSON.stringify({
+            input: {
+              user: 'testUser',
+              email: 'test@example.com',
+              userEntityRef: 'user:default/testUser',
+            },
+          }),
+        }),
+      );
     });
   });
 });

--- a/plugins/backstage-opa-backend/src/service/routers/authz.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.ts
@@ -44,8 +44,11 @@ export function authzRouter(
       });
     }
 
-    const { entryPoint: policyEntryPoint, input, includeUserEntity } =
-      parsed.data;
+    const {
+      entryPoint: policyEntryPoint,
+      input,
+      includeUserEntity,
+    } = parsed.data;
 
     const credentials = await httpAuth.credentials(req, { allow: ['user'] });
     const info = await userInfo.getUserInfo(credentials);

--- a/plugins/backstage-opa-backend/src/service/routers/authz.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.ts
@@ -7,7 +7,7 @@ import {
   UserInfoService,
 } from '@backstage/backend-plugin-api';
 import fetch from 'node-fetch';
-import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogService } from '@backstage/plugin-catalog-node';
 import { Entity } from '@backstage/catalog-model';
 
 /**
@@ -33,7 +33,7 @@ type OpaInput = {
 
 export function authzRouter(
   auth: AuthService,
-  catalogApi: CatalogApi,
+  catalog: CatalogService,
   logger: LoggerService,
   config: Config,
   httpAuth: HttpAuthService,
@@ -69,7 +69,7 @@ export function authzRouter(
           targetPluginId: 'catalog',
         });
 
-        const userEntity = await catalogApi.getEntityByRef(info.userEntityRef, {
+        const userEntity = await catalog.getEntityByRef(info.userEntityRef, {
           token,
         });
 

--- a/plugins/backstage-opa-backend/src/service/routers/authz.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.ts
@@ -40,7 +40,7 @@ export function authzRouter(
     if (!parsed.success) {
       return res.status(400).json({
         error: 'Invalid request body',
-        details: parsed.error.flatten().fieldErrors,
+        details: parsed.error.flatten(),
       });
     }
 

--- a/plugins/backstage-opa-backend/src/service/routers/authz.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import { Config } from '@backstage/config';
 import {
-  AuthService,
   HttpAuthService,
   LoggerService,
   UserInfoService,
@@ -32,7 +31,6 @@ type OpaInput = {
 } & Record<string, any>;
 
 export function authzRouter(
-  auth: AuthService,
   catalog: CatalogService,
   logger: LoggerService,
   config: Config,
@@ -64,13 +62,8 @@ export function authzRouter(
 
     if (includeUserEntity === true) {
       try {
-        const { token } = await auth.getPluginRequestToken({
-          onBehalfOf: credentials,
-          targetPluginId: 'catalog',
-        });
-
         const userEntity = await catalog.getEntityByRef(info.userEntityRef, {
-          token,
+          credentials,
         });
 
         opaInput = {

--- a/plugins/backstage-opa-backend/src/service/routers/authz.ts
+++ b/plugins/backstage-opa-backend/src/service/routers/authz.ts
@@ -8,27 +8,19 @@ import {
 import fetch from 'node-fetch';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { Entity } from '@backstage/catalog-model';
+import { z } from 'zod';
 
-/**
- * Request body structure for OPA (Open Policy Agent) authorization requests.
- */
-type OpaAuthzRequestBody = {
-  /** The input data to be evaluated by the OPA policy. */
-  input: Record<string, any>;
-  /** The policy entry point in the OPA server to evaluate against. */
-  entryPoint: string;
-  includeUserEntity?: boolean;
-};
+const opaAuthzRequestSchema = z.object({
+  entryPoint: z.string().min(1),
+  input: z.record(z.unknown()).transform(({ userEntity: _, ...rest }) => rest),
+  includeUserEntity: z.boolean().default(false),
+});
 
-/**
- * Combined input sent to OPA policies.
- * Includes user identity context from Backstage along with arbitrary request input.
- */
 type OpaInput = {
   userEntityRef: string;
   ownershipEntityRefs: string[];
   userEntity?: Entity | null;
-} & Record<string, any>;
+} & Record<string, unknown>;
 
 export function authzRouter(
   catalog: CatalogService,
@@ -43,24 +35,24 @@ export function authzRouter(
     'http://localhost:8181';
 
   router.post('/opa-authz', async (req, res) => {
-    const {
-      input,
-      entryPoint: policyEntryPoint,
-      includeUserEntity,
-    } = req.body as OpaAuthzRequestBody;
+    const parsed = opaAuthzRequestSchema.safeParse(req.body);
 
-    if (!input || !policyEntryPoint) {
-      return res
-        .status(400)
-        .json({ error: 'Missing input or entryPoint in request body' });
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Invalid request body',
+        details: parsed.error.flatten().fieldErrors,
+      });
     }
+
+    const { entryPoint: policyEntryPoint, input, includeUserEntity } =
+      parsed.data;
 
     const credentials = await httpAuth.credentials(req, { allow: ['user'] });
     const info = await userInfo.getUserInfo(credentials);
 
     let opaInput: OpaInput = { ...input, ...info };
 
-    if (includeUserEntity === true) {
+    if (includeUserEntity) {
       try {
         const userEntity = await catalog.getEntityByRef(info.userEntityRef, {
           credentials,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8801,6 +8801,7 @@ __metadata:
     node-fetch: "npm:^2.6.7"
     supertest: "npm:^6.2.4"
     yn: "npm:^4.0.0"
+    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
# 👋 Thanks for contributing

## What's this PR about?

This is the start of de-coupling the plugins dev environments from the core-app, would be nice to remove the core-app entirely from the repo.

This is the work to make that happen!

### Type of change

- [ ] 🌟 New feature
- [x] 🐛 Bug fix
- [ ] 📝 Documentation update
- [x] 🧹 Code cleanup/refactor
- [ ] ⬆️ Version bumps

### What does it solve?

Removing the core-app makes the repo much more lightweight and more easy to maintain.

### Testing

- [x] Added/updated tests
- [ ] Need help with testing
- [ ] N/A - not needed or documentation only

### Related issues

<!-- Example: Closes #123 -->

---
Need any help? Feel free to ask questions in your PR! 💬
